### PR TITLE
Fixed typo for job and added description of task

### DIFF
--- a/resources/schedule.md
+++ b/resources/schedule.md
@@ -19,7 +19,11 @@ An Xplenty **schedule** executes packages periodically starting at a specified d
     * **weeks**
     * **months**
     * **years**
-* **task**
+* **task** a task contains the following fields:
+    * **nodes** the number of compute nodes for the task to execute on.
+    * **terminate_on_idle** indicates if the cluster will terminate automatically. Default is true
+    * **time_to_idle** time after which the cluster will terminate.
+    * **packages** an array of package objects
 * **last_run_at** the date and time that schedule's task ran last
 * **last_run_status** status of the last execution of the schedule's task
 * **execution_count** number of times the schedule has run

--- a/sections/list-job-children.md
+++ b/sections/list-job-children.md
@@ -11,7 +11,7 @@ Optionally, you can supply the input parameters to filter the job list so that i
 |----|---------|-------|-----------|
 status|N|"all"|Possible values are any status listed above or ```all```. The call will return only jobs with the given status, or all the clusters if the "all" value is specified.
 sort|N|"created"|Possible values are ```updated``` or ```created```. The job list will be sorted by the jobs' "updated_at" or "created_at" value respectively.
-direction|N|"desc"|Possible values are: ```asc```, ```desc```. The jobss will be sorted in ascending or descending order of the "sort" attribute.
+direction|N|"desc"|Possible values are: ```asc```, ```desc```. The jobs will be sorted in ascending or descending order of the "sort" attribute.
 since|N| |The job list will only contain jobs updated at the given time or later. The time must be formatted as UTC in the ISO 8601 format: ```YYYY-MM-DDTHH:MM:SSZ```. Example: “2013-01-17T22:41:21Z”.
 
 ### Request (Curl Call) Syntax

--- a/sections/list-jobs.md
+++ b/sections/list-jobs.md
@@ -11,7 +11,7 @@ Optionally, you can supply the input parameters to filter the job list so that i
 |----|---------|-------|-----------|
 status|N|"all"|Possible values are any status listed above or ```all```. The call will return only jobs with the given status, or all the clusters if the "all" value is specified.
 sort|N|"created"|Possible values are ```updated``` or ```created```. The job list will be sorted by the jobs' "updated_at" or "created_at" value respectively.
-direction|N|"desc"|Possible values are: ```asc```, ```desc```. The jobss will be sorted in ascending or descending order of the "sort" attribute.
+direction|N|"desc"|Possible values are: ```asc```, ```desc```. The jobs will be sorted in ascending or descending order of the "sort" attribute.
 since|N| |The job list will only contain jobs updated at the given time or later. The time must be formatted as UTC in the ISO 8601 format: ```YYYY-MM-DDTHH:MM:SSZ```. Example: “2013-01-17T22:41:21Z”.
 
 ### Request (Curl Call) Syntax


### PR DESCRIPTION
Fixed typo for job and added description of task in the schedule definition of resource