### PR TITLE
Fix text on "Input Parameters"

### DIFF
--- a/sections/create-connection.md
+++ b/sections/create-connection.md
@@ -29,7 +29,7 @@ Create a new connection. Xplenty provides the following types of connections:
 * [Oracle Database](https://github.com/xplenty/xplenty-api-doc-v2/blob/master/resources/connections/oracle-connection.md)
 
 ### Input Parameters
-The **connection type** and **connection ID** must be supplied at the end of the request URL.
+The **connection type** must be supplied at the end of the request URL.
 
 Every connection has input attributes specific for it's type.
 


### PR DESCRIPTION
It was saying that you must pass the connection ID when creating a new connection.